### PR TITLE
UI modifications

### DIFF
--- a/src/extension/components/Conflict.tsx
+++ b/src/extension/components/Conflict.tsx
@@ -18,6 +18,18 @@ export default function Conflict({ dependency, setConflict }: ConflictProps) {
           {dependency.body.interference[dependency.body.interference.length - 1].location.class}:
           {dependency.body.interference[dependency.body.interference.length - 1].location.line}
         </p>
+      ) : dependency.body.interference[0].stackTrace &&
+        dependency.body.interference[dependency.body.interference.length - 1].stackTrace ? (
+        <p className="tw-text-gray-400">
+          in {dependency.body.interference[0].stackTrace[0].class.replaceAll(".", "/")}.java:
+          {dependency.body.interference[0].stackTrace[0].line}
+          &nbsp;&rarr;&nbsp;
+          {dependency.body.interference[
+            dependency.body.interference.length - 1
+          ].stackTrace![0].class.replaceAll(".", "/")}
+          .java:
+          {dependency.body.interference[dependency.body.interference.length - 1].stackTrace![0].line}
+        </p>
       ) : null}
     </div>
   );

--- a/src/extension/components/Conflict.tsx
+++ b/src/extension/components/Conflict.tsx
@@ -13,7 +13,10 @@ export default function Conflict({ dependency, setConflict }: ConflictProps) {
       </span>
       {dependency.body.interference[0].location.file !== "UNKNOWN" ? (
         <p className="tw-text-gray-400">
-          in {dependency.body.interference[0].location.file}:{dependency.body.interference[0].location.line}
+          in {dependency.body.interference[0].location.class}:{dependency.body.interference[0].location.line}
+          &nbsp;&rarr;&nbsp;
+          {dependency.body.interference[dependency.body.interference.length - 1].location.class}:
+          {dependency.body.interference[dependency.body.interference.length - 1].location.line}
         </p>
       ) : null}
     </div>

--- a/src/extension/components/Conflict.tsx
+++ b/src/extension/components/Conflict.tsx
@@ -5,32 +5,55 @@ interface ConflictProps {
   setConflict: (dep: dependency) => void;
 }
 
+type locationStrings = {
+  from: string;
+  to: string;
+};
+
 export default function Conflict({ dependency, setConflict }: ConflictProps) {
+  const getLocationFromStackTrace: (dep: dependency) => locationStrings = (dep: dependency) => {
+    if (
+      !dep.body.interference[0].stackTrace ||
+      !dep.body.interference[dep.body.interference.length - 1].stackTrace
+    )
+      throw new Error("File not found: Invalid stack trace");
+
+    const stackTrace0 = dep.body.interference[0].stackTrace[0];
+    const location0 = stackTrace0.class.replaceAll(".", "/") + ".java";
+
+    const stackTraceN = dep.body.interference[dep.body.interference.length - 1].stackTrace![0];
+    const locationN = stackTraceN.class.replaceAll(".", "/") + ".java";
+
+    return {
+      from: `${location0}:${stackTrace0.line}`,
+      to: `${locationN}:${stackTraceN.line}`
+    };
+  };
+
+  const getLocationStrings: (dep: dependency) => locationStrings = (dep: dependency) => {
+    const location0 = dep.body.interference[0].location;
+    const locationN = dep.body.interference[dep.body.interference.length - 1].location;
+
+    if (location0.file === "UNKNOWN" || locationN.file === "UNKNOWN") {
+      return getLocationFromStackTrace(dep);
+    } else {
+      return {
+        from: `${location0.class}:${location0.line}`,
+        to: `${locationN.class}:${locationN.line}`
+      };
+    }
+  };
+
+  const locationStrings = getLocationStrings(dependency);
+
   return (
     <div className="tw-mb-3 tw-cursor-pointer tw-w-fit" onClick={() => setConflict(dependency)}>
       <span>
         {dependency.label} ({dependency.type})&nbsp;
       </span>
-      {dependency.body.interference[0].location.file !== "UNKNOWN" ? (
-        <p className="tw-text-gray-400">
-          in {dependency.body.interference[0].location.class}:{dependency.body.interference[0].location.line}
-          &nbsp;&rarr;&nbsp;
-          {dependency.body.interference[dependency.body.interference.length - 1].location.class}:
-          {dependency.body.interference[dependency.body.interference.length - 1].location.line}
-        </p>
-      ) : dependency.body.interference[0].stackTrace &&
-        dependency.body.interference[dependency.body.interference.length - 1].stackTrace ? (
-        <p className="tw-text-gray-400">
-          in {dependency.body.interference[0].stackTrace[0].class.replaceAll(".", "/")}.java:
-          {dependency.body.interference[0].stackTrace[0].line}
-          &nbsp;&rarr;&nbsp;
-          {dependency.body.interference[
-            dependency.body.interference.length - 1
-          ].stackTrace![0].class.replaceAll(".", "/")}
-          .java:
-          {dependency.body.interference[dependency.body.interference.length - 1].stackTrace![0].line}
-        </p>
-      ) : null}
+      <p className="tw-text-gray-400">
+        in {locationStrings.from} &rarr; {locationStrings.to}
+      </p>
     </div>
   );
 }

--- a/src/extension/components/DependencyView.tsx
+++ b/src/extension/components/DependencyView.tsx
@@ -229,7 +229,7 @@ export default function DependencyView({ owner, repository, pull_number }: Depen
       {dependencies.length ? (
         <div
           id="dependency-container"
-          className="tw-min-w-fit tw-h-fit tw-mr-5 tw-py-2 tw-px-3 tw-border tw-border-gray-700 tw-rounded">
+          className="tw-min-w-fit tw-max-w-[20%] tw-h-fit tw-mr-5 tw-py-2 tw-px-3 tw-border tw-border-gray-700 tw-rounded">
           <h3 className="tw-mb-5 tw-text-red-600">
             {dependencies.length} possíveis conflito{dependencies.length > 1 ? "s" : ""} identificado
             {dependencies.length > 1 ? "s" : ""}:

--- a/src/extension/components/DependencyView.tsx
+++ b/src/extension/components/DependencyView.tsx
@@ -3,7 +3,7 @@ import AnalysisService from "../../services/AnalysisService";
 import { dependency, modLine } from "../../models/AnalysisOutput";
 import { Diff2HtmlConfig, html as diffHtml } from "diff2html";
 import { ColorSchemeType } from "diff2html/lib/types";
-import { gotoDiffConflict, removeHighlight, removeLineColor } from "../utils/diff-navigation";
+import { gotoDiffConflict, unsetAsConflictLine } from "../utils/diff-navigation";
 import Conflict from "./Conflict";
 
 const analysisService = new AnalysisService();
@@ -78,8 +78,7 @@ export default function DependencyView({ owner, repository, pull_number }: Depen
     // remove the styles from the previous conflict
     if (activeConflict.length) {
       activeConflict.forEach((line) => {
-        removeLineColor(line, modifiedLines);
-        removeHighlight(line);
+        unsetAsConflictLine(line);
       });
     }
 

--- a/src/extension/components/DependencyView.tsx
+++ b/src/extension/components/DependencyView.tsx
@@ -153,30 +153,28 @@ export default function DependencyView({ owner, repository, pull_number }: Depen
       const fileName = fileNameSpan?.textContent || "";
       setIsCollapsed((prevState) => ({
         ...prevState,
-        [fileName]: target.checked,
+        [fileName]: target.checked
       }));
     };
     
-    checkboxInputs.forEach((checkboxInput) =>{
+    checkboxInputs.forEach((checkboxInput) => {
       if (checkboxInput) {
         checkboxInput.addEventListener("change", handleChange);
       }
-    })
+    });
 
     // cleaning the event
     return () => {
-
-      checkboxInputs.forEach((checkboxInput) =>{
+      checkboxInputs.forEach((checkboxInput) => {
         if (checkboxInput) {
           checkboxInput.removeEventListener("change", handleChange);
         }
-      })
+      });
     };
   }, [diff]);
 
   //Collapsing the diff file checked as viewed
   useEffect(() => {
-    
     const diffFiles = document.querySelectorAll<HTMLElement>(".d2h-file-wrapper");
   
     // Add or remove the class `d2h-d-none` based on state `isCollapsed`
@@ -185,14 +183,11 @@ export default function DependencyView({ owner, repository, pull_number }: Depen
       const diffContainer = diffFile.querySelector(".d2h-file-diff");
       
       if (isCollapsed[fileName]) {
-        
         diffContainer?.classList.add("d2h-d-none");
       } else {
         diffContainer?.classList.remove("d2h-d-none");
       }
     });
-  
-    
   }, [isCollapsed]);
 
   return (

--- a/src/extension/components/DependencyView.tsx
+++ b/src/extension/components/DependencyView.tsx
@@ -59,7 +59,20 @@ export default function DependencyView({ owner, repository, pull_number }: Depen
 
   useEffect(() => {
     getAnalysisOutput(owner, repository, pull_number).then((response) => {
-      setDependencies(response.getDependencies());
+      setDependencies(
+        response.getDependencies().sort((a, b) => {
+          const aStartLine = a.body.interference[0].location.line;
+          const bStartLine = b.body.interference[0].location.line;
+          const aEndLine = a.body.interference[a.body.interference.length - 1].location.line;
+          const bEndLine = b.body.interference[b.body.interference.length - 1].location.line;
+
+          if (aStartLine < bStartLine) return -1;
+          if (aStartLine > bStartLine) return 1;
+          if (aEndLine < bEndLine) return -1;
+          if (aEndLine > bEndLine) return 1;
+          return 0;
+        })
+      );
       setDiff(response.getDiff());
       setModifiedLines(response.data.modifiedLines ?? []);
     });

--- a/src/extension/components/DependencyView.tsx
+++ b/src/extension/components/DependencyView.tsx
@@ -120,7 +120,7 @@ export default function DependencyView({ owner, repository, pull_number }: Depen
       {dependencies.length ? (
         <div id="dependency-container">
           <h3 className="tw-text-red-600">
-            {dependencies.length} conflito{dependencies.length > 1 ? "s" : ""} identificado
+            {dependencies.length} possíveis conflito{dependencies.length > 1 ? "s" : ""} identificado
             {dependencies.length > 1 ? "s" : ""}:
           </h3>
           <ul>

--- a/src/extension/components/DependencyView.tsx
+++ b/src/extension/components/DependencyView.tsx
@@ -129,14 +129,16 @@ export default function DependencyView({ owner, repository, pull_number }: Depen
   }, [modifiedLines]);
 
   return (
-    <>
+    <div id="dependency-plugin" className="tw-flex tw-flex-row tw-justify-between">
       {dependencies.length ? (
-        <div id="dependency-container">
-          <h3 className="tw-text-red-600">
+        <div
+          id="dependency-container"
+          className="tw-min-w-fit tw-h-fit tw-mr-5 tw-py-2 tw-px-3 tw-border tw-border-gray-700 tw-rounded">
+          <h3 className="tw-mb-5 tw-text-red-600">
             {dependencies.length} possíveis conflito{dependencies.length > 1 ? "s" : ""} identificado
             {dependencies.length > 1 ? "s" : ""}:
           </h3>
-          <ul>
+          <ul className="tw-list-none">
             {dependencies.map((d, i) => {
               return (
                 <li>
@@ -153,7 +155,7 @@ export default function DependencyView({ owner, repository, pull_number }: Depen
       ) : null}
 
       {diff ? (
-        <div id="diff-container" className="tw-mb-3">
+        <div id="diff-container" className="tw-mb-3 tw-w-full">
           <h1>Diff</h1>
           {createElement("div", { dangerouslySetInnerHTML: { __html: diffHtml(diff, diffConfig) } })}
         </div>
@@ -163,6 +165,6 @@ export default function DependencyView({ owner, repository, pull_number }: Depen
           <p>É possível que a análise ainda esteja em andamento ou que não tenha sido executada.</p>
         </div>
       )}
-    </>
+    </div>
   );
 }

--- a/src/extension/components/DependencyView.tsx
+++ b/src/extension/components/DependencyView.tsx
@@ -3,7 +3,7 @@ import AnalysisService from "../../services/AnalysisService";
 import { dependency, modLine } from "../../models/AnalysisOutput";
 import { Diff2HtmlConfig, html as diffHtml } from "diff2html";
 import { ColorSchemeType } from "diff2html/lib/types";
-import { gotoDiffConflict, removeHighlight } from "../utils/diff-navigation";
+import { gotoDiffConflict, removeHighlight, removeLineColor } from "../utils/diff-navigation";
 import Conflict from "./Conflict";
 
 const analysisService = new AnalysisService();
@@ -37,12 +37,7 @@ export default function DependencyView({ owner, repository, pull_number }: Depen
     // remove the styles from the previous conflict
     if (activeConflict.length) {
       activeConflict.forEach((line) => {
-        line.querySelectorAll("td").forEach((td) => {
-          td.classList.remove("d2h-ins-left");
-          td.classList.remove("d2h-ins");
-          td.classList.remove("d2h-del-left");
-          td.classList.remove("d2h-del");
-        });
+        removeLineColor(line, modifiedLines);
         removeHighlight(line);
       });
     }

--- a/src/extension/components/DependencyView.tsx
+++ b/src/extension/components/DependencyView.tsx
@@ -3,7 +3,11 @@ import AnalysisService from "../../services/AnalysisService";
 import { dependency, modLine } from "../../models/AnalysisOutput";
 import { Diff2HtmlConfig, html as diffHtml } from "diff2html";
 import { ColorSchemeType } from "diff2html/lib/types";
-import { gotoDiffConflict, unsetAsConflictLine } from "../utils/diff-navigation";
+import {
+  gotoDiffConflict,
+  unsetAsConflictLine,
+  updateLocationFromStackTrace
+} from "../utils/diff-navigation";
 import Conflict from "./Conflict";
 
 const analysisService = new AnalysisService();
@@ -33,25 +37,6 @@ export default function DependencyView({ owner, repository, pull_number }: Depen
   const [diff, setDiff] = useState<string>("");
   const [modifiedLines, setModifiedLines] = useState<modLine[]>([]);
   const [activeConflict, setActiveConflict] = useState<HTMLElement[]>([]); // lines of the active conflict
-
-  const updateLocationFromStackTrace = (dep: dependency) => {
-    if (
-      !dep.body.interference[0].stackTrace ||
-      !dep.body.interference[dep.body.interference.length - 1].stackTrace
-    )
-      throw new Error("File not found: Invalid stack trace");
-
-    const stackTrace0 = dep.body.interference[0].stackTrace[0];
-    const file0 = stackTrace0.class.replaceAll(".", "/") + ".java";
-
-    const stackTraceN = dep.body.interference[dep.body.interference.length - 1].stackTrace![0];
-    const fileN = stackTraceN.class.replaceAll(".", "/") + ".java";
-
-    dep.body.interference[0].location.file = file0;
-    dep.body.interference[0].location.line = stackTrace0.line;
-    dep.body.interference[dep.body.interference.length - 1].location.file = fileN;
-    dep.body.interference[dep.body.interference.length - 1].location.line = stackTraceN.line;
-  };
 
   const filterDuplicatedDependencies = (dependencies: dependency[]) => {
     const uniqueDependencies: dependency[] = [];

--- a/src/extension/styles/dependency-plugin.css
+++ b/src/extension/styles/dependency-plugin.css
@@ -1,5 +1,16 @@
+.pl-conflict-line {
+  border-left-width: 2px;
+  border-left-style: solid;
+  border-left-color: rgb(250 204 21) /* #facc15 */;
+}
+
+.pl-conflict-line > :first-child > :first-child {
+  color: rgb(250 204 21) /* #facc15 */;
+}
+
 .pl-line-highlight {
   border-width: 1px;
+  border-left-width: 2px;
   border-style: solid;
   border-color: transparent;
   animation: fadeInBorder 0.3s forwards 0.1s;
@@ -7,7 +18,7 @@
 
 .pl-line-highlight.pl-fadeout-border {
   border-color: rgb(250 204 21) /* #facc15 */;
-  animation: fadeOutBorder 3s forwards 0.1s;
+  animation: fadeOutBorder 1s forwards 0.1s;
 }
 
 @keyframes fadeInBorder {
@@ -19,5 +30,6 @@
 @keyframes fadeOutBorder {
   to {
     border-color: transparent;
+    border-left-color: rgb(250 204 21) /* #facc15 */;
   }
 }

--- a/src/extension/styles/tailwind.css
+++ b/src/extension/styles/tailwind.css
@@ -33,6 +33,10 @@
   width: 100% !important;
 }
 
+.tw-max-w-\[20\%\] {
+  max-width: 20% !important;
+}
+
 .tw-h-fit {
   height: fit-content !important;
 }

--- a/src/extension/styles/tailwind.css
+++ b/src/extension/styles/tailwind.css
@@ -3,8 +3,38 @@
   margin-bottom: 0.75rem /* 12px */ !important;
 }
 
+.tw-mb-5 {
+  margin-bottom: 1.25rem /* 20px */ !important;
+}
+
+.tw-mr-5 {
+  margin-right: 1.25rem /* 20px */ !important;
+}
+
+.tw-px-3 {
+  padding-left: 0.75rem /* 12px */ !important;
+  padding-right: 0.75rem /* 12px */ !important;
+}
+
+.tw-py-2 {
+  padding-top: 0.5rem /* 8px */ !important;
+  padding-bottom: 0.5rem /* 8px */ !important;
+}
+
 .tw-w-fit {
   width: fit-content !important;
+}
+
+.tw-min-w-fit {
+  min-width: fit-content !important;
+}
+
+.tw-w-full {
+  width: 100% !important;
+}
+
+.tw-h-fit {
+  height: fit-content !important;
 }
 
 .tw-text-gray-200 {
@@ -35,7 +65,32 @@
   border: 1px solid !important;
 }
 
+.tw-rounded {
+  border-radius: 0.25rem /* 4px */ !important;
+}
+
 .tw-border-yellow-400 {
   --tw-border-opacity: 1 !important;
   border-color: rgb(250 204 21 / var(--tw-border-opacity)) /* #facc15 */ !important;
+}
+
+.tw-border-gray-700 {
+  --tw-border-opacity: 1 !important;
+  border-color: rgb(55 65 81 / var(--tw-border-opacity)) /* #374151 */ !important;
+}
+
+.tw-flex {
+  display: flex !important;
+}
+
+.tw-flex-row {
+  flex-direction: row !important;
+}
+
+.tw-justify-between {
+  justify-content: space-between !important;
+}
+
+.tw-list-none {
+  list-style-type: none !important;
 }

--- a/src/extension/utils/diff-navigation.ts
+++ b/src/extension/utils/diff-navigation.ts
@@ -1,4 +1,4 @@
-import { interferenceNode, modLine } from "../../models/AnalysisOutput";
+import { interferenceNode, modLine, dependency } from "../../models/AnalysisOutput";
 
 const fadeOutBorder = (diffLine: HTMLElement) => {
   diffLine.classList.add("pl-fadeout-border");
@@ -164,6 +164,29 @@ const unsetAsConflictLine = (diffLine: HTMLElement) => {
   leftLineNumber.removeAttribute("prev-text");
 };
 
+const updateLocationFromStackTrace = (dep: dependency) => {
+  if (
+    !dep.body.interference[0].stackTrace ||
+    !dep.body.interference[dep.body.interference.length - 1].stackTrace
+  )
+    throw new Error("File not found: Invalid stack trace");
+
+  const stackTrace0 = dep.body.interference[0].stackTrace[0];
+  const file0 = stackTrace0.class.replaceAll(".", "/") + ".java";
+
+  const stackTraceN = dep.body.interference[dep.body.interference.length - 1].stackTrace![0];
+  const fileN = stackTraceN.class.replaceAll(".", "/") + ".java";
+
+  dep.body.interference[0].location.file = file0;
+  dep.body.interference[0].location.line = stackTrace0.line;
+  dep.body.interference[0].location.class = stackTrace0.class;
+  dep.body.interference[dep.body.interference.length - 1].location.file = fileN;
+  dep.body.interference[dep.body.interference.length - 1].location.line = stackTraceN.line;
+  dep.body.interference[dep.body.interference.length - 1].location.class = stackTraceN.class;
+
+  return dep;
+};
+
 const getDiffLine = (file: string, line: number) => {
   // try to get the line element by id
   let lineElement = document.getElementById(`${file}:${line}`);
@@ -235,5 +258,6 @@ export {
   unsetAsConflictLine,
   removeLineColor,
   scrollAndHighlight,
-  getDiffLine
+  getDiffLine,
+  updateLocationFromStackTrace
 };

--- a/src/extension/utils/diff-navigation.ts
+++ b/src/extension/utils/diff-navigation.ts
@@ -46,6 +46,33 @@ const setColorFromBranch = (diffLine: HTMLElement, branch: "L" | "R", colorType:
   });
 };
 
+const removeLineColor = (diffLine: HTMLElement, modifiedLines?: modLine[]) => {
+  if (modifiedLines) {
+    const file = diffLine.id.split(":")[0];
+    const line = parseInt(diffLine.id.split(":")[1]);
+
+    const fileModifiedLines = modifiedLines.find((ml) => ml.file.endsWith(file) || file.endsWith(ml.file));
+    if (!fileModifiedLines) return;
+
+    if (
+      fileModifiedLines.leftAdded.includes(line) ||
+      fileModifiedLines.rightAdded.includes(line) ||
+      fileModifiedLines.leftRemoved.includes(line) ||
+      fileModifiedLines.rightRemoved.includes(line)
+    ) {
+      console.info(`Line ${line} of file ${file} was modified, not removing color`);
+      return;
+    }
+  }
+
+  diffLine.querySelectorAll("td").forEach((td) => {
+    td.classList.remove("d2h-ins-left");
+    td.classList.remove("d2h-ins");
+    td.classList.remove("d2h-del-left");
+    td.classList.remove("d2h-del");
+  });
+};
+
 const checkLineModificationType = (file: string, line: number) => {
   // get the diffLine element
   let diffLine = getDiffLine(file, line);

--- a/src/extension/utils/diff-navigation.ts
+++ b/src/extension/utils/diff-navigation.ts
@@ -97,22 +97,29 @@ const findSourceBranch = (node: interferenceNode, modifiedLines: modLine[]) => {
   const firstNodeFromLine = node.stackTrace?.[0].line;
   if (!firstNodeFromLine) return null;
 
-  // check if the line is in the modified lines
-  const fileModifiedLines = modifiedLines.find((ml) => ml.file.endsWith(firstNodeFromFile));
-  if (!fileModifiedLines) return null;
-
+  // check if the node has already a set branch
   let branch: "L" | "R" | null = null;
-  if (
-    fileModifiedLines.leftAdded.includes(firstNodeFromLine) ||
-    fileModifiedLines.leftRemoved.includes(firstNodeFromLine)
-  )
-    branch = "L";
-  else if (
-    fileModifiedLines.rightAdded.includes(firstNodeFromLine) ||
-    fileModifiedLines.rightRemoved.includes(firstNodeFromLine)
-  )
-    branch = "R";
-  else return null;
+  if (node.branch) {
+    branch = node.branch;
+  } else {
+    // check if the line is in the modified lines
+    const fileModifiedLines = modifiedLines.find(
+      (ml) => ml.file.endsWith(firstNodeFromFile) || firstNodeFromFile.endsWith(ml.file)
+    );
+    if (!fileModifiedLines) return null;
+
+    if (
+      fileModifiedLines.leftAdded.includes(firstNodeFromLine) ||
+      fileModifiedLines.leftRemoved.includes(firstNodeFromLine)
+    )
+      branch = "L";
+    else if (
+      fileModifiedLines.rightAdded.includes(firstNodeFromLine) ||
+      fileModifiedLines.rightRemoved.includes(firstNodeFromLine)
+    )
+      branch = "R";
+    else return null;
+  }
 
   // check if the line was added or removed
   const lineType: "ins" | "del" | "change" | null = checkLineModificationType(
@@ -190,4 +197,4 @@ const gotoDiffConflict = (
   return [lineFrom, lineTo];
 };
 
-export { gotoDiffConflict, highlight, removeHighlight, scrollAndHighlight, getDiffLine };
+export { gotoDiffConflict, highlight, removeHighlight, removeLineColor, scrollAndHighlight, getDiffLine };


### PR DESCRIPTION
# What was added?

- [x] Conflict log is now simplified and sorted by line number
- [x] When a conflict is selected, all the lines involved are highlighted until another conflict is selected (in contrast to the temporary highlighting done previously)

# What was fixed?

- [x] Duplicated conflicts are now filtered in the log
- [x] Extension now searchs for a valid file when the conflict's file is "UNKNOWN"